### PR TITLE
Updates to include css templates and also robots.txt templates

### DIFF
--- a/app/asset-types/page.inc.php
+++ b/app/asset-types/page.inc.php
@@ -29,7 +29,7 @@ Class Page {
   }
   
   function parse_template() {
-    return TemplateParser::parse($this->data, file_get_contents($this->template_file));
+    return TemplateParser::parse($this->data, file_get_contents($this->template_file), $this);
   }
   
   # magic variable assignment

--- a/app/cache.inc.php
+++ b/app/cache.inc.php
@@ -14,9 +14,11 @@ Class Cache {
     $this->cachefile = './app/_cache/'.$this->base64_url($_SERVER['REQUEST_URI']);
     # collect an md5 of all files
     $this->hash = $this->create_hash();
-    # if we're serving JSON, using js-appropriate comment tags
+    # if we're serving JSON or CSS, use appropriate comment tags
     preg_match('/\.([\w\d]+?)$/', $this->page->template_file, $split_path);
-    if ($split_path[1] == 'json' || $split_path[1] == 'js') $this->comment_tags = array('/*', '*/');
+    if ($split_path[1] == 'json' || $split_path[1] == 'js' || $split_path[1] == 'css') $this->comment_tags = array('/*', '*/');
+    # robots.txt files need # comments in order to not break
+    if ($split_path[1] == 'txt') $this->comment_tags = array('#', '');
   }
   
   function base64_url($input) {

--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -211,10 +211,24 @@ Class PageData {
       $relative_path = preg_replace('/^\.\//', Helpers::relative_root_path(), $page->file_path);
       $colon_split[1] = preg_replace('/\@path/', $relative_path.'/', $colon_split[1]);
       
+      # get template file type as $split_path[1]
+      preg_match('/\.([\w\d]+?)$/', $page->template_file, $split_path); 
       # set a variable with a name of 'key' on the page with a value of 'value'
-      $page->$colon_split[0] = 
-        # if the 'value' contains a newline character, parse it as markdown
-        (strpos($colon_split[1], "\n") === false) ? trim($colon_split[1]) : Markdown(trim($colon_split[1]));
+      switch ($split_path[1]) {
+        case "txt":
+          $page->$colon_split[0] = trim($colon_split[1]);
+          break;
+        case "css":
+          # potentially put a less css parser here?
+          $page->$colon_split[0] = trim($colon_split[1]);
+          break;
+        default :
+          $page->$colon_split[0] = 
+            # if the 'value' contains a newline character, parse it as markdown
+            (strpos($colon_split[1], "\n") === false) ? 
+              trim($colon_split[1]) : Markdown(trim($colon_split[1]));
+          break;
+      }
     }
   }
   

--- a/app/stacey.inc.php
+++ b/app/stacey.inc.php
@@ -54,6 +54,9 @@ Class Stacey {
         # set json/utf-8 charset header
         header('Content-type: application/json; charset=utf-8');
         break;
+      case 'css':
+        header('Content-type: text/css; charset=utf-8');
+        break;
       default:
         # set html/utf-8 charset header
         header("Content-type: text/html; charset=utf-8");

--- a/content/robots/robots.txt
+++ b/content/robots/robots.txt
@@ -1,0 +1,5 @@
+custom_robots:
+
+User-Agent: Googlebot
+Disallow: @root_path/about/
+-

--- a/content/style/style.txt
+++ b/content/style/style.txt
@@ -1,0 +1,13 @@
+custom_styles:
+
+/* fonts used */
+@font-face {
+  font-family: 'CallunaRegular';
+  src: url('@root_path/public/docs/type/calluna-regular-webfont.eot');
+  src: local('☺'), url('@root_path/public/docs/type/calluna-regular-webfont.woff') format('woff'), url('@root_path/public/docs/type/calluna-regular-webfont.ttf') format('truetype'), url('@root_path/public/docs/type/calluna-regular-webfont.svg#webfontlrtqnawB') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+
+body{font-family:"CallunaRegular"};
+-

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,0 +1,6 @@
+# www.robotstxt.org/
+# www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
+
+User-agent: *
+
+@custom_robots

--- a/templates/style.css
+++ b/templates/style.css
@@ -1,0 +1,120 @@
+html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp,
+small, strong, sub, sup, var, b, i, dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, figure, footer, header, hgroup, menu, nav, section, menu,
+time, mark, audio, video {
+  margin:0;
+  padding:0;
+  border:0;
+  outline:0;
+  font-size:100%;
+  vertical-align:baseline;
+  background:transparent;
+}                  
+article, aside, figure, footer, header, hgroup, nav, section { display:block; }
+nav ul { list-style:none; }
+blockquote, q { quotes:none; }
+blockquote:before, blockquote:after, q:before, q:after { content:''; content:none; }
+a { margin:0; padding:0; font-size:100%; vertical-align:baseline; background:transparent; }
+ins { background-color:#ff9; color:#000; text-decoration:none; }
+mark { background-color:#ff9; color:#000; font-style:italic; font-weight:bold; }
+del { text-decoration: line-through; }
+abbr[title], dfn[title] { border-bottom:1px dotted #000; cursor:help; }
+table { border-collapse:collapse; border-spacing:0; }
+hr { display:block; height:1px; border:0; border-top:1px solid #ccc; margin:1em 0; padding:0; }
+input, select { vertical-align:middle; }
+
+
+body { font:13px sans-serif; *font-size:small; *font:x-small; line-height:1.22; }
+table { font-size:inherit; font:100%; }
+select, input, textarea { font:99% sans-serif; }
+pre, code, kbd, samp { font-family: monospace, sans-serif; }
+ 
+body, select, input, textarea { color:#444; }
+h1,h2,h3,h4,h5,h6 { font-weight: bold; text-rendering: optimizeLegibility; }
+html { -webkit-font-smoothing: antialiased; }
+a:hover, a:active { outline: none; }
+a, a:active, a:visited { color:#607890; }
+a:hover { color:#036; }
+ul { margin-left:30px; }
+ol { margin-left:30px; list-style-type: decimal; }
+small { font-size:85%; }
+strong, th { font-weight: bold; }
+td, td img { vertical-align:top; } 
+sub { vertical-align: sub; font-size: smaller; }
+sup { vertical-align: super; font-size: smaller; }
+
+pre { padding: 15px; white-space: pre; white-space: pre-wrap; white-space: pre-line; word-wrap: break-word; }
+
+input[type="radio"] { vertical-align: text-bottom; }
+input[type="checkbox"] { vertical-align: bottom; *vertical-align: baseline; }
+.ie6 input { vertical-align: text-bottom; }
+label, input[type=button], input[type=submit], button { cursor: pointer; }
+
+::-moz-selection{ background: #FF5E99; color:#fff; text-shadow: none; }
+::selection { background:#FF5E99; color:#fff; text-shadow: none; } 
+
+a:link { -webkit-tap-highlight-color: #FF5E99; } 
+
+
+html { overflow-y: scroll; }
+button {  width: auto; overflow: visible; }
+.ie7 img { -ms-interpolation-mode: bicubic; }
+
+.ir { display:block; text-indent:-999em; overflow:hidden; background-repeat: no-repeat; }
+.hidden { display:none; visibility:hidden; } 
+.visuallyhidden { position:absolute !important; clip: rect(1px 1px 1px 1px); clip: rect(1px, 1px, 1px, 1px); }
+.invisible { visibility: hidden; }
+.clearfix:after { content: "."; display: block; height: 0; clear: both; visibility: hidden; }
+.clearfix { display: inline-block; }
+* html .clearfix { height: 1%; }
+.clearfix { display: block; }
+
+
+ /* Primary Styles
+    Author: 
+ */
+
+@custom_styles
+
+
+
+
+
+
+
+
+
+/* 
+ * print styles
+ */
+@media print {
+  * { background: transparent !important; color: #444 !important; text-shadow: none; }
+  a, a:visited { color: #444 !important; text-decoration: underline; }
+  a:after { content: " (" attr(href) ")"; } 
+  abbr:after { content: " (" attr(title) ")"; }
+  .ir a:after { content: ""; }  /* Don't show links for images */
+  pre, blockquote { border: 1px solid #999; page-break-inside: avoid; }
+  img { page-break-inside: avoid; }
+  @page { margin: 0.5cm; }
+  p, h2, h3 { orphans: 3; widows: 3; }
+  h2, h3{ page-break-after: avoid; }
+}
+
+
+
+@media all and (orientation:portrait) { 
+  
+}
+
+@media all and (orientation:landscape) { 
+  
+}
+
+/* Grade-A Mobile Browsers */
+@media screen and (max-device-width: 480px) {
+  html { -webkit-text-size-adjust:none; -ms-text-size-adjust:none; } 
+
+}
+


### PR DESCRIPTION
Hi there!

While i was working on the stacey-html5-boilerplate fork, i ran into some issues because i was hoping to use both robots.txt files and some stacey vars in my css files, so i made these changes to stacey. They're roughly:
1. adding css content-type to stacey.inc.php
2. updating stacey version comments in cache.inc.php to include css files and also
3. adding # comments for text files (in particular, robots.txt)
4. in page-data.inc.php conditionally turning off markdown processing for txt and css files (with the potential to include other parsers for specific content-types here)
5. passing $page around to TemplateParser to turn off escaping @s in txt and css files

arguably the last two are the most controversial, but i needed to get both of them in so that i could make sure that text-ish files get treated correctly and not like html files (point 4 is particularly apparent in robots.txt files, while point 5 is more relevant to turning off @s being escaped incorrectly in css files.

Let me know what you think, or if the coding style is incompatible. I tried to make the changes as obvious (and commit messages clear) and as unobtrusive as possible while respecting your 'house style.'

Thanks for the great platform, 
--marcos
