### PR TITLE
Removing comments from JSON files

### DIFF
--- a/content/json/json_feed.txt
+++ b/content/json/json_feed.txt
@@ -1,0 +1,1 @@
+feed_name: Portfolio Feed

--- a/templates/json_feed.json
+++ b/templates/json_feed.json
@@ -6,8 +6,17 @@ foreach $root do
       {
         "title": "@title",
         "thumb": "@thumb",
+        "url": "@url",
+        "date": "@date",
+        "updated": "@updated",
         "title": "@title",
-        "url": "@url"
+        "content": "@content",   
+        "images": [
+          foreach $images do
+            "url": "@url",
+            "name": "@name"
+          endforeach
+          ],
       }
       if !@is_last do
       ,

--- a/templates/json_feed.json
+++ b/templates/json_feed.json
@@ -1,0 +1,19 @@
+{
+foreach $root do  
+  if $children do
+    "projects": [
+    foreach $children do
+      {
+        "title": "@title",
+        "thumb": "@thumb",
+        "title": "@title",
+        "url": "@url"
+      }
+      if !@is_last do
+      ,
+      endif
+    endforeach
+    ]
+  endif
+endforeach
+}


### PR DESCRIPTION
Hi Anthony,

I'm in the process of rebuilding my site and I'm making use of Stacey's JSON support. I noticed that my AJAX calls were failing because MooTools was saying that the returned JSON was invalid. I ran the output through a couple of online validators and sure enough, it was invalid with the footer comment. I did a little more research and found that there is apparently no comment delimiter to the JSON spec.

I posted a comment on the Get Satisfaction forum the other day:
http://getsatisfaction.com/stacey/topics/json_files_outputted_by_stacey_cant_be_parsed_with_jquery

... but I figured it made more sense to offer a fix for the issue. This commit includes the following:

In cache.inc.php:
- A $filetype class variable which uses your regex, but now wrapped in a set_filetype() function.
- An array for filetypes that should not get comments. Right now this is just json, but if more come up in the future, they can just be added here.
- A new array for defining start/end comment tags. It's now a little easier to see what's going on and it'll be easier to add new ones in the future.

I also created a json example template, so the example site now outputs a JSON object with the projects when you hit /json. The only minor snag I hit there was that when I output the array of images, I only want to put a comma after the entry when we're not on the last image (which I _can_ do with the array of projects, using @is_last), but I didn't see a variable that can check that.

Anyhow, take a look over my changes and let me know what you think. I can be reached at jason@blackantmedia.com.

Thanks!

Jason
