### PR TITLE
Markdown

### DIFF
--- a/app/parsers/markdown-parser.inc.php
+++ b/app/parsers/markdown-parser.inc.php
@@ -1767,7 +1767,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
   ### HTML Block Parser ###
   
   # Tags that are always treated as block tags:
-  var $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend';
+  var $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend|article|aside|audio|figure|footer|header|hgroup|nav|section|video';
   
   # Tags treated as block tags only if the opening tag is alone on it's line:
   var $context_block_tags_re = 'script|noscript|math|ins|del';


### PR DESCRIPTION
Just noticed the PHP markdown is a bit out of date. I got the HTML output like this: `<p><video></p>something<p></video></p>`. So I added some common HTML5 tags here to let them treated as block tags.
