### PR TITLE
Bypass cache directive

### DIFF
--- a/app/cache.inc.php
+++ b/app/cache.inc.php
@@ -56,7 +56,7 @@ Class Cache {
 
   function get_current_hash() {
     preg_match('/Stacey.*: (.+?)\s/', file_get_contents($this->cachefile), $matches);
-    return $matches[1];
+    return isset($matches[1]) ? $matches[1] : false;
   }
 
   function write_cache() {

--- a/app/cache.inc.php
+++ b/app/cache.inc.php
@@ -39,7 +39,7 @@ Class Cache {
     ob_start();
       echo $page->parse_template();
       # if cache folder is writable, write to it
-      if(is_writable('./app/_cache')) $this->write_cache();
+      if(is_writable('./app/_cache') && $page->data['@cache_page']) $this->write_cache();
       else if ($this->is_commentable()) echo "\n".$this->comment_tags['begin'].' Stacey('.Stacey::$version.'). '.$this->comment_tags['end'];
     # end buffer
     ob_end_flush();
@@ -56,7 +56,7 @@ Class Cache {
 
   function get_current_hash() {
     preg_match('/Stacey.*: (.+?)\s/', file_get_contents($this->cachefile), $matches);
-    return isset($matches[1]) ? $matches[1] : false;
+    return $matches[1];
   }
 
   function write_cache() {

--- a/app/cache.inc.php
+++ b/app/cache.inc.php
@@ -39,7 +39,7 @@ Class Cache {
     ob_start();
       echo $page->parse_template();
       # if cache folder is writable, write to it
-      if(is_writable('./app/_cache') && $page->data['@cache_page']) $this->write_cache();
+      if(is_writable('./app/_cache') && !$page->data['@bypass_cache']) $this->write_cache();
       else if ($this->is_commentable()) echo "\n".$this->comment_tags['begin'].' Stacey('.Stacey::$version.'). '.$this->comment_tags['end'];
     # end buffer
     ob_end_flush();

--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -144,7 +144,7 @@ Class PageData {
     $page->is_first = $page->data['@index'] == 1;
 
 	# @cache_page
-	$page->cache_page = (isset($page->data['@cache_page']) && ($page->data['@cache_page'] == true)) || (!isset($page->data['@cache_page']));
+	$page->bypass_cache = isset($page->data['@bypass_cache']) ? $page->data['@bypass_cache'] : false;
 
   }
 

--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -107,7 +107,7 @@ Class PageData {
     # @permalink
     $page->permalink = Helpers::modrewrite_parse($page->url_path.'/');
     # @slug
-      $split_url = explode("/", $page->url_path);
+    $split_url = explode("/", $page->url_path);
     $page->slug = $split_url[count($split_url) - 1];
     # @page_name
     $page->page_name = ucfirst(preg_replace('/[-_](.)/e', "' '.strtoupper('\\1')", $page->data['@slug']));
@@ -142,6 +142,10 @@ Class PageData {
     $page->is_last = $page->data['@index'] == $page->data['@siblings_count'];
     # @is_first
     $page->is_first = $page->data['@index'] == 1;
+
+	# @cache_page
+	$page->cache_page = (isset($page->data['@cache_page']) && ($page->data['@cache_page'] == true)) || (!isset($page->data['@cache_page']));
+
   }
 
   static function create_collections($page) {

--- a/app/parsers/template-parser.inc.php
+++ b/app/parsers/template-parser.inc.php
@@ -20,7 +20,15 @@ Class TemplateParser {
 
     foreach(self::$partials as $partial) {
       if(preg_match('/([^\/]+?)\.[\w]+?$/', $partial, $file_name)) {
-        if($file_name[1] == $name) return file_get_contents($partial);
+		 //if($file_name[1] == $name) return file_get_contents($partial);
+		 if($file_name[1] == $name)
+		 {
+			ob_start();
+			include $partial;
+			$ob_contents = ob_get_contents();
+			ob_end_clean();
+			return $ob_contents;
+		 } 
       }
     }
     return 'Partial \''.$name.'\' not found';


### PR DESCRIPTION
This is the same kind of change as my previous (now closed) request. However, this time I've made the semantics a little less confusing, I hope.

Now, if you define a variable in your page called "@bypass_cache" and set it to something that evaluates to true, the page output will not be written to cache. Otherwise, cache as normal in Stacey.

Note that this patch includes the patch to allow PHP execution in partials from https://github.com/nacholabs/stacey/commit/aab941eb072ea52685966575b939fa5bc6e055c8
