### PR TITLE
Fix @is_current to work on index page.

### DIFF
--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -68,7 +68,7 @@ Class PageData {
 
   static function is_current($base_url, $permalink) {
     $base_path = preg_replace('/^[^\/]+/', '', $base_url);
-    if($permalink == 'index') {
+    if(preg_match("/^(\?\/)?index\/?$/i", $permalink)) {
       return ('/' == $_SERVER['REQUEST_URI']);
     } else {
       return ($base_path.'/'.$permalink == $_SERVER['REQUEST_URI']);


### PR DESCRIPTION
@is_current currently doesn't work when the index page is included in the $root loop to produce site navigation.

I've replaced the simple check for the permalink to == 'index' with a preg_replace with matches either '?/index/' (without htaccees), or just 'index/' (with htaccess).

Cheers,
Jack
