### PR TITLE
page.id

### DIFF
--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -118,6 +118,8 @@ Class PageData {
     $page->site_updated = strval(date('c', Helpers::site_last_modified()));
     # page.updated
     $page->updated = strval(date('c', Helpers::last_modified($page->file_path)));
+    # page.id
+    $page->id = "p" . md5($_SERVER['HTTP_HOST'] . $page->data['permalink']);
 
     # page.siblings_count
     $page->siblings_count = strval(count($page->data['siblings_and_self']));

--- a/templates/page.html
+++ b/templates/page.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ page.root_path }}/public/docs/css/screen.css" type="text/css" media="screen"> 
   </head>
   <body>
-    <div id="container">
+    <div id="container" class="{{ page.id }}">
       <h1 class="col three">
         <a href="{{ page.root_path }}">{{ page.name }}</a>
         <strong>{{ page.profession }}</strong>

--- a/templates/partials/navigation/category-lists.html
+++ b/templates/partials/navigation/category-lists.html
@@ -2,7 +2,7 @@
   {% if child.children %}
     <ul class="projects">
     {% for child in child.children %}
-      <li class="col seven">
+      <li class="col seven {{ child.id }}">
         <p class="date col one">{{ child.date | date("Y, M-") }}</p>
         <h2 class="col five">
           {% if child.thumb %}

--- a/templates/project.html
+++ b/templates/project.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ page.root_path }}/public/docs/css/screen.css" type="text/css" media="screen"> 
   </head>
   <body>
-    <div id="container">
+    <div id="container" class="{{ page.id }}">
       <h1 class="col three">
         <a href="{{ page.root_path }}">{{ page.name }}</a>
         <strong>{{ page.profession }}</strong>


### PR DESCRIPTION
Added a page.id variable for every page based on Host and Permalink, being expressed as a md5 hash of the above. This is to enable easily and uniquely identifying a page using a flexible alphanumeric string, i.e. instead of concatenating slugs, names etc.
