### PR TITLE
Shorter page id

### DIFF
--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -119,7 +119,7 @@ Class PageData {
     # page.updated
     $page->updated = strval(date('c', Helpers::last_modified($page->file_path)));
     # page.id
-    $page->id = "p" . md5($_SERVER['HTTP_HOST'] . $page->data['permalink']);
+    $page->id = "p" . substr(md5($_SERVER['HTTP_HOST'] . $page->data['permalink']), 0, 6);
 
     # page.siblings_count
     $page->siblings_count = strval(count($page->data['siblings_and_self']));


### PR DESCRIPTION
Updated page id to only use the last 6 bytes of the md5. Much more compact, saving a bit of download bandwidth as well, since the full md5 is certainly an overkill.
