### PR TITLE
GitHub style line breaks

### DIFF
--- a/app/asset-types/asset-factory.inc.php
+++ b/app/asset-types/asset-factory.inc.php
@@ -13,6 +13,14 @@ Class AssetFactory {
 
     # return any page data scoped against the asset filename
     $page_data = self::$store[$page_path];
+
+    foreach ($page_data[$file_name] as $key => $value) {
+      # Parse markdown is newline is found
+      if (strpos($value, "\n") !== false) {
+        $page_data[$file_name][$key] = Markdown( trim( $value ) ); 
+      }
+    }
+    
     return isset($page_data[$file_name]) ? $page_data[$file_name] : false;
   }
 

--- a/app/asset-types/md.inc.php
+++ b/app/asset-types/md.inc.php
@@ -1,0 +1,27 @@
+<?php
+
+Class Md extends Asset {
+
+  static $identifiers = array('md', 'markdown');
+
+  function __construct($file_path) {
+    # create and store data required for this asset
+    parent::__construct($file_path);
+    # create and store additional data required for this asset
+    $this->set_extended_data($file_path);
+  }
+
+  function set_extended_data($file_path) {
+    if(is_readable($file_path)) {
+      ob_start();
+      include $file_path;
+      $this->data['content'] = Markdown(ob_get_contents());
+      ob_end_clean();
+    } else {
+      $this->data['content'] = '';
+    }
+  }
+
+}
+
+?>

--- a/app/asset-types/page.inc.php
+++ b/app/asset-types/page.inc.php
@@ -54,9 +54,9 @@ Class Page {
   }
 
   static function template_name($file_path) {
-    $txts = array_keys(Helpers::list_files($file_path, '/\.(yml|txt)/'));
+    $txts = array_keys(Helpers::list_files($file_path, '/\.(yml)/'));
     # return first matched .yml file
-    return (!empty($txts)) ? preg_replace('/\.(yml|txt)/', '', $txts[0]) : false;
+    return (!empty($txts)) ? preg_replace('/\.(yml)/', '', $txts[0]) : false;
   }
 
   static function template_file($template_name) {

--- a/app/asset-types/txt.inc.php
+++ b/app/asset-types/txt.inc.php
@@ -1,0 +1,27 @@
+<?php
+
+Class Txt extends Asset {
+
+  static $identifiers = array('text', 'txt');
+
+  function __construct($file_path) {
+    # create and store data required for this asset
+    parent::__construct($file_path);
+    # create and store additional data required for this asset
+    $this->set_extended_data($file_path);
+  }
+
+  function set_extended_data($file_path) {
+    if(is_readable($file_path)) {
+      ob_start();
+      include $file_path;
+      $this->data['content'] = Markdown(ob_get_contents());
+      ob_end_clean();
+    } else {
+      $this->data['content'] = '';
+    }
+  }
+
+}
+
+?>

--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -179,6 +179,8 @@ Class PageData {
     $page->images = Helpers::list_files($page->file_path, '/(?<!thumb|_lge|_sml)\.(gif|jpg|png|jpeg)$/i', false);
     # page.video
     $page->video = Helpers::list_files($page->file_path, '/\.(mov|mp4|m4v)$/i', false);
+    # page.txt
+    $page->txt = Helpers::list_files($page->file_path, '/\.(txt)$/i', false);
 
     # page.swf, page.html, page.doc, page.pdf, page.mp3, etc.
     # create a variable for each file type included within the page's folder (excluding .yml files)
@@ -232,6 +234,22 @@ Class PageData {
         $page->$key = trim($value);
       }
     }
+
+    $txt_files = Helpers::list_files($page->file_path, '/\.(txt)$/i', false);
+
+    # Save each txt file as page variable
+    foreach ($txt_files as $filename => $file_path) {
+      $var_name = preg_replace('/\.(txt)/', '', $filename);
+      if(is_readable($file_path)) {
+        ob_start();
+        include $file_path;
+        $page->$var_name = Markdown(ob_get_contents());
+        ob_end_clean();
+      } else {
+        $page->$var_name = '';
+      }
+    }
+
   }
 
   static function html_to_xhtml(&$value) {

--- a/app/parsers/markdown-parser.inc.php
+++ b/app/parsers/markdown-parser.inc.php
@@ -5,6 +5,9 @@
 # PHP Markdown & Extra
 # Copyright (c) 2004-2009 Michel Fortin  
 # <http://michelf.com/projects/php-markdown/>
+# 
+# Modified to preserve line breaks, line #667
+# <http://stackoverflow.com/questions/2092966/how-to-treat-single-newline-as-real-line-break-in-php-markdown>
 #
 # Original Markdown
 # Copyright (c) 2004-2006 John Gruber  
@@ -661,7 +664,7 @@ class Markdown_Parser {
   
   function doHardBreaks($text) {
     # Do hard breaks:
-    return preg_replace_callback('/ {2,}\n/', 
+    return preg_replace_callback('/ {2,}\n|\n{1}/', 
       array(&$this, '_doHardBreaks_callback'), $text);
   }
   function _doHardBreaks_callback($matches) {

--- a/content/1.projects/1.project-1/content.txt
+++ b/content/1.projects/1.project-1/content.txt
@@ -1,0 +1,8 @@
+content.txt hello world
+
+fsd
+fsd 
+
+
+
+fsd fsdf

--- a/content/1.projects/1.project-1/project.yml
+++ b/content/1.projects/1.project-1/project.yml
@@ -3,8 +3,7 @@ title: The Test Project 1
 date: March 10, 2002
 
 content: |
-  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-  Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  let's see who wins
 
 01.jpg:
   description: CAPTION

--- a/templates/project.html
+++ b/templates/project.html
@@ -21,6 +21,17 @@
         <div class="description col six">
           <h2 class="col six"><a href="{{ page.root_path }}">{{ page.title }}</a></h2>
           {{ page.content }}
+
+          {% for md in page.md %}
+            <div class="{{ md.name|lower }}">{{ md.content }}</div>
+          {% endfor %}
+
+          {% for txt in page.txt %}
+            <div class="{{ txt.name|lower }}">{{ txt.content }}</div>
+          {% endfor %}
+
+          {{ pebug(page) }}
+
         </div>
         <hr>
         <p id="project-count" class="col one"><em>&#8470;</em> {{ page.index }}/{{ page.siblings_count }}</p>


### PR DESCRIPTION
I always found Markdown's line break policy counter-intuitive. GitHub and [Jeff Atwood](http://meta.stackoverflow.com/questions/26011/should-the-markdown-renderer-treat-a-single-line-break-as-br) seem to agree. I've modified the markdown parser so that it preserves line breaks. 
