### PR TITLE
Add page.next_siblings and page.previous_siblings

### DIFF
--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -157,6 +157,10 @@ Class PageData {
     $page->siblings = Helpers::list_files($parent_path, '/^\d+?\.(?!'.$split_url[(count($split_url) - 1)].')/', true);
     # page.siblings_and_self
     $page->siblings_and_self = Helpers::list_files($parent_path, '/^\d+?\./', true);
+    # page.next_siblings / page.previous_siblings
+    $index = self::get_index($page->data['siblings_and_self'], $page->file_path);
+    $page->previous_siblings = array_slice($page->data['siblings_and_self'], 0, $index, true);
+    $page->next_siblings = array_slice($page->data['siblings_and_self'], $index, count($page->data['siblings_and_self']), true);
     # page.next_sibling / page.previous_sibling
     $neighboring_siblings = self::extract_closest_siblings($page->data['siblings_and_self'], $page->file_path);
     $page->previous_sibling = array($neighboring_siblings[0]);


### PR DESCRIPTION
Useful when moving up the parents tree and trying to find out what the siblings of the parent are. 
