### PR TITLE
re: #image-holder: changed max-width for chrome 21 bug

### DIFF
--- a/public/docs/css/screen.css
+++ b/public/docs/css/screen.css
@@ -67,7 +67,7 @@ div#project-navigation { margin: 0px 0px 0px 20px; }
 div#project-navigation p, div#gallery-navigation p { margin: 0px 0px 1px; }
 
 div#image-wrapper { overflow: hidden; width: 560px; }
-div#image-wrapper div#image-holder { width: 100000000px; }
+div#image-wrapper div#image-holder { width: 35791394px; }
 div#image-wrapper div#image-holder div.image { float: left; width: 560px; }
 
 img.project-thumb { padding: 0px 10px 5px 0px; float: left; display: none; }


### PR DESCRIPTION
The width of the #image-holder (originally '100000000px') was breaking for me in Chrome 21. After some research, I found that the max width of Chrome 21 is set at '35791394px'.

While this might be a Chrome bug, the original CSS certainly affected the current Stacey app.
