### PR TITLE
Fix for error when _shared.yml not exist.

### DIFF
--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -193,6 +193,8 @@ Class PageData {
     $shared_file_path = file_exists(Config::$content_folder.'/_shared.yml') ? Config::$content_folder.'/_shared.yml' : Config::$content_folder.'/_shared.txt';
     if (file_exists($shared_file_path)) {
       return self::$shared = sfYaml::load($shared_file_path);
+    } else {
+      return array();
     }
   }
 


### PR DESCRIPTION
When neither _shared.yml nor _shared.txt exist, the app attempts to
merge a null reference. This returns an empty array as a fix. This is
useful when the app does not need any global variables (and no
_shared.yml file).
