### PR TITLE
Allow LB Handling Choice, Defaults to GFM Style

### DIFF
--- a/app/parsers/markdown-parser.inc.php
+++ b/app/parsers/markdown-parser.inc.php
@@ -6,13 +6,20 @@
 # Copyright (c) 2004-2009 Michel Fortin  
 # <http://michelf.com/projects/php-markdown/>
 #
-# Modified to preserve line breaks, line #667
+# Modified to preserve line breaks, line #675
 # <http://stackoverflow.com/questions/2092966/how-to-treat-single-newline-as-real-line-break-in-php-markdown>
+#
+# Modified to allow user to choose preference (set in extensions/config.php
+# file), line #674-#679
+# <https://github.com/kolber/stacey/issues/82>
 #
 # Original Markdown
 # Copyright (c) 2004-2006 John Gruber  
 # <http://daringfireball.net/projects/markdown/>
 #
+
+# Require Stacey configs
+require_once(dirname(dirname(dirname(__FILE__))).'/extensions/config.php');
 
 
 define( 'MARKDOWN_VERSION',  "1.0.1n" ); # Sat 10 Oct 2009
@@ -664,8 +671,12 @@ class Markdown_Parser {
   
   function doHardBreaks($text) {
     # Do hard breaks:
-    return preg_replace_callback('/ {2,}\n|\n{1}/',
-      array(&$this, '_doHardBreaks_callback'), $text);
+    if (Config::$md_gfm_style_linebreaks) {
+      return preg_replace_callback('/ {2,}\n|\n{1}/',array(&$this, '_doHardBreaks_callback'), $text);
+    }
+    else {
+      return preg_replace_callback('/ {2,}\n/',array(&$this, '_doHardBreaks_callback'), $text);
+    }  
   }
   function _doHardBreaks_callback($matches) {
     return $this->hashPart("<br$this->empty_element_suffix\n");

--- a/extensions/config.php
+++ b/extensions/config.php
@@ -2,6 +2,8 @@
 
 class Config {
 
+  /* STACEY CORE SETUP */
+
   public static $root_folder = './';
   public static $app_folder = './app';
   public static $content_folder = './content';
@@ -9,6 +11,16 @@ class Config {
   public static $cache_folder = './app/_cache';
   public static $extensions_folder = './extensions';
 
+  /* STACEY CUSTOMIZATIONS */
+
+  // [ Markdown_GithubFlavoredMarkdown_LineBreaks]
+  // The biggest difference that GFM introduces is in the handling of
+  // linebreaks. With SM you can hard wrap paragraphs of text and they will be
+  // combined into a single paragraph. They (Github) find this to be the cause
+  // of a huge number of unintentional formatting errors and have GFM treat
+  // newlines in paragraph-like content as real line breaks, which could be what
+  // was intended. Defaults to use GFM style linebreaks
+  public static $md_gfm_style_linebreaks = true;
 }
 
 ?>


### PR DESCRIPTION
- Less technical users tend to find the default Markdown linebreak
  handling confusing. Which was the reason for the change in the first
  place but this allows for one to choose which handling works best for
  their use case
- Defaults to Github-style-line-breaks for those who are already
  accustomed
- Probably going forward all customizations could be in the
  extensions/config.php ... figured that was elegant-ish/the best place to
  put it
